### PR TITLE
Improve site design with blog layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Personal MSP Developer Site
 
-This repository contains a simple personal website for a developer who builds coding and IT solutions for Managed Service Providers. It features a short introduction, an about page with skills, and a contact section.
+This repository contains a personal website for a developer who builds coding and IT solutions for Managed Service Providers. The site now features a small blog section on the home page along with an about page and contact information.
 
 Open `index.html` in your browser to view the site.

--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@
       <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
     </nav>
   </header>
-  <main class="container">
+  <main class="container about">
     <h1>About Me</h1>
     <p>I'm John Doe, a developer focused on building tools and automations for Managed Service Providers. I love creating efficient solutions that help teams deliver great service.</p>
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,23 @@
       <p class="tagline">Coding &amp; IT Solutions for MSPs</p>
       <a class="btn" href="about.html">Learn More</a>
     </section>
+    <section class="posts">
+      <article class="post">
+        <h2>Welcome to My Blog</h2>
+        <p class="post-meta">April 20, 2024</p>
+        <p>This is where I'll share tips and updates about automation for MSPs. Stay tuned!</p>
+      </article>
+      <article class="post">
+        <h2>Building Better Workflows</h2>
+        <p class="post-meta">March 15, 2024</p>
+        <p>Automation can transform your MSP business. I'll show you how to get started.</p>
+      </article>
+      <article class="post">
+        <h2>Why I Love Coding</h2>
+        <p class="post-meta">February 8, 2024</p>
+        <p>I've been coding for years and it's a passion that keeps growing.</p>
+      </article>
+    </section>
   </main>
   <footer>
     <p>&copy; 2024 John Doe</p>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,15 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   margin: 0;
   padding: 0;
   line-height: 1.6;
-  background-color: #f0f0f0;
+  background-color: #f8f9fa;
   color: #333;
 }
 
 .container {
   width: 90%;
-  max-width: 960px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 1em;
 }
@@ -58,12 +58,15 @@ nav button {
 
 .hero {
   text-align: center;
-  padding: 3em 1em;
+  padding: 4em 1em;
+  background: linear-gradient(135deg, #007acc, #00aaff);
+  color: #fff;
 }
 
 .hero .tagline {
   font-size: 1.2em;
   margin: 0.5em 0 1em;
+  opacity: 0.9;
 }
 
 .btn {
@@ -72,11 +75,44 @@ nav button {
   padding: 0.75em 1.5em;
   text-decoration: none;
   border-radius: 4px;
+  display: inline-block;
 }
 
 .skills {
   list-style: square inside;
   padding-left: 0;
+}
+
+.posts {
+  margin-top: 2em;
+}
+
+.post {
+  background: #fff;
+  padding: 1.5em;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1.5em;
+}
+
+.post h2 {
+  margin-top: 0;
+}
+
+.post-meta {
+  color: #777;
+  font-size: 0.9em;
+  margin-bottom: 0.5em;
+}
+
+.about {
+  text-align: center;
+  margin-top: 2em;
+}
+
+.about .skills {
+  display: inline-block;
+  text-align: left;
 }
 
 footer {
@@ -103,4 +139,17 @@ footer {
 
 .dark-theme .btn {
   background-color: #005a99;
+}
+
+.dark-theme .post {
+  background: #333;
+  color: #f0f0f0;
+}
+
+.dark-theme .post-meta {
+  color: #bbb;
+}
+
+.dark-theme .about .skills li {
+  color: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- modernize styles with better fonts, gradient hero and cards
- add a simple blog section on the homepage
- center the about page content
- update README to mention the blog

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684153e06dd88321bfbf70cad7279ec1