### PR TITLE
Add sample blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Personal MSP Developer Site
 
-This repository contains a personal website for a developer who builds coding and IT solutions for Managed Service Providers. The site now features a small blog section on the home page along with an about page and contact information.
+This repository contains a personal website for a developer who builds coding and IT solutions for Managed Service Providers. The site features a home page, an about page, and a growing blog section.
 
-Open `index.html` in your browser to view the site.
+Open `index.html` in your browser to view the site. Visit `posts.html` to read example blog posts.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
+        <li><a href="posts.html">Blog</a></li>
       </ul>
       <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
     </nav>
@@ -25,19 +26,19 @@
     </section>
     <section class="posts">
       <article class="post">
-        <h2>Welcome to My Blog</h2>
-        <p class="post-meta">April 20, 2024</p>
-        <p>This is where I'll share tips and updates about automation for MSPs. Stay tuned!</p>
+        <h2><a href="posts/automating-ticket-workflows.html">Automating Ticket Workflows with Python</a></h2>
+        <p class="post-meta">May 5, 2024</p>
+        <p>Automation is key for MSP efficiency. Read how Python helps streamline ticket management.</p>
       </article>
       <article class="post">
-        <h2>Building Better Workflows</h2>
-        <p class="post-meta">March 15, 2024</p>
-        <p>Automation can transform your MSP business. I'll show you how to get started.</p>
+        <h2><a href="posts/powershell-daily-tasks.html">PowerShell for Daily Tasks</a></h2>
+        <p class="post-meta">April 22, 2024</p>
+        <p>PowerShell can help with everyday tasks in an MSP environment.</p>
       </article>
       <article class="post">
-        <h2>Why I Love Coding</h2>
-        <p class="post-meta">February 8, 2024</p>
-        <p>I've been coding for years and it's a passion that keeps growing.</p>
+        <h2><a href="posts/managing-cloud-backups.html">Managing Cloud Backups</a></h2>
+        <p class="post-meta">March 30, 2024</p>
+        <p>Reliable backups are essential for every MSP. Learn strategies for the cloud.</p>
       </article>
     </section>
   </main>

--- a/posts.html
+++ b/posts.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>About - John Doe</title>
+  <title>Blog - John Doe</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -18,20 +18,13 @@
       <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
     </nav>
   </header>
-  <main class="container about">
-    <h1>About Me</h1>
-    <p>I'm John Doe, a developer focused on building tools and automations for Managed Service Providers. I love creating efficient solutions that help teams deliver great service.</p>
-
-    <h2>Skills</h2>
-    <ul class="skills">
-      <li>Python &amp; Automation</li>
-      <li>PowerShell Scripting</li>
-      <li>Cloud Integrations</li>
-      <li>Web Development</li>
+  <main class="container">
+    <h1>Blog Posts</h1>
+    <ul class="post-list">
+      <li><a href="posts/automating-ticket-workflows.html">Automating Ticket Workflows with Python</a> <span class="post-meta">May 5, 2024</span></li>
+      <li><a href="posts/powershell-daily-tasks.html">PowerShell for Daily Tasks</a> <span class="post-meta">April 22, 2024</span></li>
+      <li><a href="posts/managing-cloud-backups.html">Managing Cloud Backups</a> <span class="post-meta">March 30, 2024</span></li>
     </ul>
-
-    <h2>Contact</h2>
-    <p>I'd love to connect! Email me at <a href="mailto:johndoe@example.com">johndoe@example.com</a>.</p>
   </main>
   <footer>
     <p>&copy; 2024 John Doe</p>

--- a/posts/automating-ticket-workflows.html
+++ b/posts/automating-ticket-workflows.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Automating Ticket Workflows with Python</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <nav class="container">
+      <div class="logo"><a href="../index.html">John Doe</a></div>
+      <ul>
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../posts.html">Blog</a></li>
+      </ul>
+      <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
+    </nav>
+  </header>
+  <main class="container">
+    <article class="post">
+      <h1>Automating Ticket Workflows with Python</h1>
+      <p class="post-meta">May 5, 2024</p>
+      <p>Automation is key for MSP efficiency. In this post I show how to manage helpdesk tickets using Python scripts to save time and reduce manual work.</p>
+    </article>
+  </main>
+  <footer>
+    <p>&copy; 2024 John Doe</p>
+  </footer>
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/posts/managing-cloud-backups.html
+++ b/posts/managing-cloud-backups.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Managing Cloud Backups</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <nav class="container">
+      <div class="logo"><a href="../index.html">John Doe</a></div>
+      <ul>
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../posts.html">Blog</a></li>
+      </ul>
+      <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
+    </nav>
+  </header>
+  <main class="container">
+    <article class="post">
+      <h1>Managing Cloud Backups</h1>
+      <p class="post-meta">March 30, 2024</p>
+      <p>Reliable backups are essential for every MSP. This article walks through strategies for managing cloud backups and ensuring data is protected.</p>
+    </article>
+  </main>
+  <footer>
+    <p>&copy; 2024 John Doe</p>
+  </footer>
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/posts/powershell-daily-tasks.html
+++ b/posts/powershell-daily-tasks.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PowerShell for Daily Tasks</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <nav class="container">
+      <div class="logo"><a href="../index.html">John Doe</a></div>
+      <ul>
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../posts.html">Blog</a></li>
+      </ul>
+      <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
+    </nav>
+  </header>
+  <main class="container">
+    <article class="post">
+      <h1>PowerShell for Daily Tasks</h1>
+      <p class="post-meta">April 22, 2024</p>
+      <p>PowerShell can help with everyday tasks in an MSP environment, from user management to automated reporting. Here are some scripts to get you started.</p>
+    </article>
+  </main>
+  <footer>
+    <p>&copy; 2024 John Doe</p>
+  </footer>
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,14 @@ nav button {
   margin-top: 2em;
 }
 
+.post-list {
+  list-style: none;
+  padding-left: 0;
+}
+.post-list li {
+  margin-bottom: 1em;
+}
+
 .post {
   background: #fff;
   padding: 1.5em;


### PR DESCRIPTION
## Summary
- add new posts directory and `posts.html`
- link to blog in nav across the site
- show sample blog post excerpts on the homepage
- provide basic styling for blog lists
- update README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684164e1b6c48321bdd9b97ce9d26203