### PR TITLE
Add expandable code blocks with syntax highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,11 @@
         <p class="post-meta">March 30, 2024</p>
         <p>Reliable backups are essential for every MSP. Learn strategies for the cloud.</p>
       </article>
+      <article class="post">
+        <h2><a href="posts/hello-world-examples.html">Hello World Examples</a></h2>
+        <p class="post-meta">May 20, 2024</p>
+        <p>See how to print <code>Hello World</code> in Bash and Python with colorful, expandable code blocks.</p>
+      </article>
     </section>
   </main>
   <footer>

--- a/posts.html
+++ b/posts.html
@@ -24,6 +24,7 @@
       <li><a href="posts/automating-ticket-workflows.html">Automating Ticket Workflows with Python</a> <span class="post-meta">May 5, 2024</span></li>
       <li><a href="posts/powershell-daily-tasks.html">PowerShell for Daily Tasks</a> <span class="post-meta">April 22, 2024</span></li>
       <li><a href="posts/managing-cloud-backups.html">Managing Cloud Backups</a> <span class="post-meta">March 30, 2024</span></li>
+      <li><a href="posts/hello-world-examples.html">Hello World Examples</a> <span class="post-meta">May 20, 2024</span></li>
     </ul>
   </main>
   <footer>

--- a/posts/hello-world-examples.html
+++ b/posts/hello-world-examples.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hello World Scripts</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+</head>
+<body>
+  <header>
+    <nav class="container">
+      <div class="logo"><a href="../index.html">John Doe</a></div>
+      <ul>
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../posts.html">Blog</a></li>
+      </ul>
+      <button id="toggle-theme" aria-label="Toggle theme">🌙</button>
+    </nav>
+  </header>
+  <main class="container">
+    <article class="post">
+      <h1>Hello World Examples</h1>
+      <p class="post-meta">May 20, 2024</p>
+      <p>This post demonstrates how to print "Hello World" in a few common scripting languages.</p>
+
+      <section class="code-block">
+        <button class="code-toggle" aria-expanded="false">Show Bash Example</button>
+        <pre><code class="language-bash">echo "Hello World"</code></pre>
+      </section>
+
+      <section class="code-block">
+        <button class="code-toggle" aria-expanded="false">Show Python Example</button>
+        <pre><code class="language-python">print("Hello World")</code></pre>
+      </section>
+
+    </article>
+  </main>
+  <footer>
+    <p>&copy; 2024 John Doe</p>
+  </footer>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -15,4 +15,17 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
+
+  document.querySelectorAll('.code-block').forEach(function(block) {
+    const button = block.querySelector('.code-toggle');
+    const pre = block.querySelector('pre');
+    if (button && pre) {
+      pre.style.display = 'none';
+      button.addEventListener('click', function() {
+        const isHidden = pre.style.display === 'none';
+        pre.style.display = isHidden ? 'block' : 'none';
+        button.setAttribute('aria-expanded', isHidden);
+      });
+    }
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -161,3 +161,34 @@ footer {
 .dark-theme .about .skills li {
   color: #f0f0f0;
 }
+
+.code-block {
+  margin: 1em 0;
+}
+
+.code-block pre {
+  background: #1e1e1e;
+  color: #f8f8f2;
+  padding: 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+  display: none;
+}
+
+.code-block .code-toggle {
+  background-color: #007acc;
+  color: #fff;
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dark-theme .code-block pre {
+  background: #333;
+  color: #f0f0f0;
+}
+
+.dark-theme .code-block .code-toggle {
+  background-color: #005a99;
+}


### PR DESCRIPTION
## Summary
- enable show/hide code blocks with script updates
- style code blocks for light and dark modes
- add a blog post demonstrating Bash and Python hello world examples
- link new post from index and blog listing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841a7e7558c8321a2a3865f5260d48b